### PR TITLE
Implement another option to prune voxels

### DIFF
--- a/fairnr/clib/src/intersect_gpu.cu
+++ b/fairnr/clib/src/intersect_gpu.cu
@@ -435,12 +435,10 @@ __global__ void uniform_ray_sampling_kernel(
       if (umax == max_hits || ucur == max_steps || pts_idx[H + umax] == -1) {
         break;  // reach the maximum
       }
-      if (umin < max_hits && pts_idx[H + umin] > -1) {
+      if (umin < max_hits) {
         last_min_depth = min_depth[H + umin];
-      } else {
-        last_min_depth = last_max_depth + 0.1;
       }
-      if (umax < max_hits && pts_idx[H + umin] > -1) {
+      if (umax < max_hits) {
         last_max_depth = max_depth[H + umax];
       }
       if (ucur < max_steps) {

--- a/fairnr/models/fairnr_model.py
+++ b/fairnr/models/fairnr_model.py
@@ -69,6 +69,9 @@ class BaseModel(BaseFairseqModel):
     # def forward(self, ray_start, ray_dir, ray_split=1, **kwargs):
     def forward(self, ray_split=1, **kwargs):
         ray_start, ray_dir, uv = self.reader(**kwargs)
+        kwargs.update({
+            'field_fn': self.field.forward,
+            'input_fn': self.encoder.forward})
 
         if ray_split == 1:
             results = self._forward(ray_start, ray_dir, **kwargs)

--- a/fairnr/modules/renderer.py
+++ b/fairnr/modules/renderer.py
@@ -213,9 +213,13 @@ class VolumeRenderer(Renderer):
                 {name: s[i: i+chunk_size] for name, s in samples.items()}, *args, **kwargs)
             for i in range(0, ray_start.size(0), chunk_size)
         ]
-        return {name: torch.cat([r[name] for r in results], 0) 
+        results = {name: torch.cat([r[name] for r in results], 0) 
                     if results[0][name].dim() > 0 else sum([r[name] for r in results])
                 for name in results[0]}
+
+        if getattr(input_fn, "track_max_probs", False):
+            input_fn.track_voxel_probs(samples['sampled_point_voxel_idx'].long(), results['probs'])
+        return results
         
 
 @register_renderer("resampled_volume_rendering")

--- a/fairnr_cli/train.py
+++ b/fairnr_cli/train.py
@@ -77,6 +77,8 @@ def main(args, init_distributed=False):
         trainer = Trainer(args, task, model, criterion)
     else:
         trainer = MegatronTrainer(args, task, model, criterion)
+        
+    task.setup_trainer(trainer)
 
     logger.info('training on {} GPUs'.format(args.distributed_world_size))
     logger.info('max tokens per GPU = {} and max sentences per GPU = {}'.format(


### PR DESCRIPTION
Instead of using density to prune voxels, we also try another option to prune based on training set statistics. 
For example, we can use the maximum probability of each voxel over the training rays to determine whether to keep or drop the voxels.
In practice, it works similar to the original method, but much slower as it needs to go over all training images.