### PR TITLE
fix bug in the ending condition of inverse_cdf_sampling_kernel

### DIFF
--- a/fairnr/clib/src/sample_gpu.cu
+++ b/fairnr/clib/src/sample_gpu.cu
@@ -185,7 +185,7 @@ __global__ void inverse_cdf_sampling_kernel(
         }
         
         // if there are bins still remained
-        while ((z_low < curr_max_depth) && (~done)) {
+        while ((z_low < curr_max_depth) && (!done)) {
             sampled_idx[K + s] = pts_idx[H + curr_bin];
             sampled_dists[K + s] = (curr_max_depth - z_low);
             sampled_depth[K + s] = (curr_max_depth + z_low) * .5;


### PR DESCRIPTION
In C++, ~ operator cannot be used to invert bool variable. 